### PR TITLE
fix: Insert context when the commit source is empty

### DIFF
--- a/src/prepare-commit-msg-context/prepare-commit-msg
+++ b/src/prepare-commit-msg-context/prepare-commit-msg
@@ -3,14 +3,14 @@
 set -e
 
 COMMIT_MSG_FILE="${1}"
-COMMIT_SOURCE=$2
-SHA1=$3
+COMMIT_SOURCE="${2}"
+SHA1="${3}"
 
-echo "" >> "${COMMIT_MSG_FILE}"
-git diff --cached | sed 's/^/# /' >> "${COMMIT_MSG_FILE}"
+case "${COMMIT_SOURCE},${SHA1}" in
+    ",")
+        echo "" >> "${COMMIT_MSG_FILE}"
+        git diff --cached | sed 's/^/# /' >> "${COMMIT_MSG_FILE}"
 
-case "$COMMIT_SOURCE,$SHA1" in
-    ,|template,)
         echo "" >> "${COMMIT_MSG_FILE}"
         echo "# Recent History" >> "${COMMIT_MSG_FILE}"
         git log --oneline --graph --decorate -n 10 | sed 's/^/# /' >> "${COMMIT_MSG_FILE}" ;;


### PR DESCRIPTION
When the commit source is empty, the commit is created by the
`git commit` command.
