### PR TITLE
ci: Add release-prepare-commit-msg-context.yml

### DIFF
--- a/.github/release-prepare-commit-msg-context.yml
+++ b/.github/release-prepare-commit-msg-context.yml
@@ -1,0 +1,21 @@
+changelog:
+  categories:
+    - title: Breaking change
+      labels:
+        - "scope: prepare-commit-msg-context"
+        - "sem-pr: breaking change"
+    - title: Features
+      labels:
+        - "scope: prepare-commit-msg-context"
+        - "sem-pr: feat"
+    - title: Bug Fixes
+      labels:
+        - "scope: prepare-commit-msg-context"
+        - "sem-pr: fix"
+    - title: Other Changes
+      labels:
+        - "scope: prepare-commit-msg-context"
+        - "*"
+  exclude:
+    authors:
+      - dependabot


### PR DESCRIPTION
It use to generates release notes for prepare-commit-msg-context feature.
