### PR TITLE
ci: Add "sem-pr: docs" label to automatically created PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,5 +43,5 @@ jobs:
           # Push
           if [ "$NO_UPDATES" != "true" ] ; then
               git push origin "$branch"
-              gh pr create --title "docs: $message" --body "$message"
+              gh pr create --title "docs: $message" --body "$message" --label  "sem-pr: docs" 
           fi


### PR DESCRIPTION
The PR created by the "release.yml" workflow does not trigger the "label.yml"
workflow because it contains "[skip ci]".

Therefore, add a label when creating a PR.
